### PR TITLE
Add new env PACKAGE_SUFFIX to differentiate the packages

### DIFF
--- a/jenkins-stack/casc_configs/jenkins-base.encrypted.secret.shared.yaml
+++ b/jenkins-stack/casc_configs/jenkins-base.encrypted.secret.shared.yaml
@@ -4,32 +4,36 @@ jenkins:
         - envVars:
             env:
                 - key: CDH_PASS_INT
-                  value: ENC[AES256_GCM,data:KWUkLMnGgs6EIXlygNc=,iv:0s5bzjqwlm96tk6Lhmh4Dw3f7vBElIp1XvH4cJZzjTA=,tag:B+O/3GA/XSGwHfKQXpFoQw==,type:str]
+                  value: ENC[AES256_GCM,data:3aFZ9SZft9X6N4UXHAY=,iv:oDB+mgFKnMDWWTb7TOiGrl7xghXDR268JYehF4NITqs=,tag:d8G3FPWI8PVt3MA2QXYPzw==,type:str]
                 - key: CDH_PASS_PROD
-                  value: ENC[AES256_GCM,data:YGLvFgfCBly2fV7UvKk=,iv:HkUToRyUG1txqnXUJoSwlp76DpbrDQqqtVeZ8ah7EJI=,tag:O9PEHpk1mxorLN73wDvq8Q==,type:str]
+                  value: ENC[AES256_GCM,data:Nj4C4qqRgdgHf4ylugs=,iv:59jTP3NSCoPfX6RD/SZ2gchXMAjRBowGFYQ3Ea9MXYI=,tag:k5WNgzEQzYxveb2lOHxh1w==,type:str]
                 - key: CDH_PASS_QA
-                  value: ENC[AES256_GCM,data:w5ZvnBLQarc1Dvlcauw=,iv:HB/pVLY/ljbqyb6QQzPDBqKPzsT8NJ0TR6N/1748kvk=,tag:FAkF+rOi3Ssz1S9lGKNbJg==,type:str]
+                  value: ENC[AES256_GCM,data:FgwfN3W7ngccR7gkf+4=,iv:c4r5O1Gf1rrHWKgm4XJIIuBwKTtC6QmtssXYHO7IRdk=,tag:+cc3WKyEdTiuCHaJoQpgWg==,type:str]
                 - key: CDH_USR_INT
-                  value: ENC[AES256_GCM,data:0RTM,iv:BGh0AqHqHzEBdqO0uzLmEa2K+hvCdQ2DIFMYOQk51/M=,tag:Oz4SCtAVwR7SoY2Z6PvK9Q==,type:str]
+                  value: ENC[AES256_GCM,data:8s4G,iv:FbAQiJIlvsGj34rX1lHPvMRq7g+/bHsqnYK2AuMUNik=,tag:Zhr+WAHzVHob7NaH1lzcSw==,type:str]
                 - key: CDH_USR_PROD
-                  value: ENC[AES256_GCM,data:g+z8,iv:amk0Kxebf32CxpCFPH2XRSHl19GU6O79XoiSju4VONg=,tag:MDW0eVlsA2Dh4UQd1++8IQ==,type:str]
+                  value: ENC[AES256_GCM,data:HIx/,iv:OYorhQVhrc9WhavOjKxJgIgtRfBgOqvx/a6W5k8nt9c=,tag:GPErlMi6WEmV+ywOaOKhlw==,type:str]
                 - key: CDH_USR_QA
-                  value: ENC[AES256_GCM,data:wd9H,iv:q/sJhTuofZCv9j77u1GbghLhWNLvdLi/U1x5L0OZPbM=,tag:HMRypvvHiHDFYOI3CIl1gg==,type:str]
+                  value: ENC[AES256_GCM,data:ZXTQ,iv:e88/a9dOx5Wj/z+8XCB7ZuAGWMpvYT2y5O7Kfvz51CI=,tag:GtcahGSqxA4QEVEARJttEQ==,type:str]
                 - key: CDN_SFTP_BASE
-                  value: ENC[AES256_GCM,data:zUvCqLsNsiu5gA==,iv:hcG0bXxptuvco6FsMfL47/uC2BooKqWiB/yZ1oJQj38=,tag:7ftvBf1ftCfvd+vEJCuh4Q==,type:str]
+                  value: ENC[AES256_GCM,data:ikSJeOPIxDybug==,iv:HOgngBGVSq/OmWNDKr0yhzqogYK0wMaLsLju4FnBMN8=,tag:x2VWPum9o6oYyJD3p0i0fA==,type:str]
                 - key: CDN_SFTP_HOSTNAME
-                  value: ENC[AES256_GCM,data:0E5D0KiMrH/fia3xslxQzZSw9OA/u4oC3A==,iv:l1b8HDaG9ntChrG94zcJN8pexTh0nf8OgBdJOLHKO8I=,tag:OsmAMsMWualN2vGHR4ENJg==,type:str]
+                  value: ENC[AES256_GCM,data:kzK16ebkHRCQ/ldz5DceysbMrI7ZFiaOaw==,iv:78VEJHXhxRNA9pS6fijfIDsZ/auwsK72i+It+LZg+WA=,tag:HhhIfbAfTGgYlirM2C8MqQ==,type:str]
                 - key: CDN_SFTP_PORT
-                  value: ENC[AES256_GCM,data:VkqdYw==,iv:HoiLxoHQH9qCs6zDjdoQzf647aOE/e+noHajjvWLWp4=,tag:DYL61yynxG14AN0dYb7FMw==,type:str]
+                  value: ENC[AES256_GCM,data:AiD/kA==,iv:Bgq4iFXRdG3JquqNpiQ4ZercSC9OSpomClsIFWzD+iw=,tag:87c0EMOcTdyFFg+ZVT4d+w==,type:str]
                 - key: CDN_SFTP_USERNAME
-                  value: ENC[AES256_GCM,data:wPCO87RV+flA7g==,iv:gqy6pIwuNafKCTaAzh7aMVLhgITsbLcjojEpBW3wbgA=,tag:K6yvaCpCGuNpw7bE0UI8+A==,type:str]
+                  value: ENC[AES256_GCM,data:SrwRPz+VYk+WGg==,iv:0dHRlxDIo1qH+kVK+cg9ORIOjkL7OUOhpifVtqXQJXE=,tag:ZCVj08TkCyhOiyf3YEUMbQ==,type:str]
                 - key: GH_TOKEN
-                  value: ENC[AES256_GCM,data:PuMqgf9mKFc2X9EAlAXTCoCEeakW2dR277IAJKqdVyFp3JC3jaEJoA==,iv:lNOUd9F2N8DNsD8OjtLOTRZ4jZ3y9Eg7x7WOOVqR6hY=,tag:z6nCSalRHAHwEHA4HExAFA==,type:str]
+                  value: ENC[AES256_GCM,data:lKboGPVs3yYCpgD8nsQh9brzF3xdkver/jrupT5jooMFaVCfKIiHSA==,iv:NOn8TpKTlUl5YTUP8Vpx2xj6yrWZ9VJAPrXfpU6pIhI=,tag:mmug7E4fs/LQEW4ebE5xZg==,type:str]
+                - key: PACKAGE_SUFFIX
+                  # It is a suffix to differentiate the packages generated with the new jenkins
+                  # TODO: remove the suffix when we start to use the new Jenkins service
+                  value: ENC[AES256_GCM,data:sdqfow==,iv:G4AHdHa0TL0FW+rC9GcqQM5yaqHv4koPk1AOsOO/TkE=,tag:cgd0Nm21WRJcQtqWLkyyXA==,type:str]
 unclassified:
     # https://app.dopplerrelay.com/#/settings/connection-settings
     mailer:
         authentication:
-            password: ENC[AES256_GCM,data:2iKaMZmG0UJjKOwKV4+ZMe9QMzw=,iv:MtbQF61/WyPMs6eVCJtWAEh71ElDdL233zvkaanixHs=,tag:nNykez+CD3f6IwhYh1Uz4w==,type:str]
+            password: ENC[AES256_GCM,data:R6GR5uNwZGruKgmBAuP6WMrqCvQ=,iv:9qQaGkWkpzlH8WBCZsT1LlDIqN5rY+2CRUW+TlGIBws=,tag:yknQiBR9csGFyJZI8OZv0Q==,type:str]
             username: devdoppler@fromdoppler.com
         charset: UTF-8
         replyToAddress: devdoppler@fromdoppler.com
@@ -46,18 +50,18 @@ credentials:
                     # https://hub.docker.com/settings/security
                     # Access Token Description: NewJenkins
                     id: dockerhub_dopplerdock
-                    password: ENC[AES256_GCM,data:XLAd9G1QvfLHZm7/5z1ue3H80fxmVVI8S1N0Sp2g6fJ6Ecil,iv:x1MIQ1/ltbwcp+mk3OMBSGKsmpx2AEsRb5SGasBylfg=,tag:wB33r6IdKvzTe8o7+Ahfew==,type:str]
+                    password: ENC[AES256_GCM,data:uViJuda70kRRzbqUcbRoH1Pl27B4xzbbVFmPtdXG4/YifAnM,iv:dvWVxanjwZWPlEP50OQVOC0hmw916lUKsx+8JpGOgcA=,tag:B8k9Dz4tcp/RyPomEJbtmg==,type:str]
                     scope: GLOBAL
                     username: dopplerdock
                     usernameSecret: true
                 - string:
                     id: aws-doppler-fun-jenkins-cicd-id
                     scope: GLOBAL
-                    secret: ENC[AES256_GCM,data:Iild4/gnPMXiv9mrttwTgCBGgXI=,iv:jedQs7iM24J65JyalQVyONEZxCFC8Q7c9e6Pg8kitu0=,tag:oZsD6KuWihiwuYFnQn4VNg==,type:str]
+                    secret: ENC[AES256_GCM,data:uLH9TCjH6xPKuyuPUBMCcirqoHQ=,iv:meqfvdwR+e8KtDQ2Ihv+eO/GviRFblbI/Dg9j+XYiZY=,tag:E74p3voSYGfhuVMnZqDcjQ==,type:str]
                 - string:
                     id: aws-doppler-fun-jenkins-cicd-key
                     scope: GLOBAL
-                    secret: ENC[AES256_GCM,data:CmFkXtqJcjackUliovGG4Hs3AMPapqEzgoTwVfTSInjhSe5QL0a43w==,iv:E4MO+2NY9k0xD7K4yFeagwGtL2GK3vu2E/+fj4tydGg=,tag:ulHxTsLXWn+uJ1r4/T1PVQ==,type:str]
+                    secret: ENC[AES256_GCM,data:MYztKwY8SMLi+o4GZW9mY6o+00JJu2reMv38bLaWqRcnn+fK1zrnMg==,iv:KdTO1n+LzBwGyu0i4N1Dsk1Do3B2CdbHq++MpIQ6iwg=,tag:xK7bLTMzDwxNDVT6nz6s4w==,type:str]
             - domain:
                 name: main
 sops:
@@ -66,37 +70,37 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-27T19:44:51Z"
-    mac: ENC[AES256_GCM,data:QWOkavLUkSF7aHcUu+HhvbqQGM3uJpDRikAubbSX8+ISVJygSJSMdmhzKVzpKNedEOft28+4FQBEVlEq+NwOQs3dt+b1Sag5t7ga5xOh1Y0vJU5y35H5AnC3QDh77LlpVk2iy5h2ZJrBL7dmXM3HQJ/IJ27Sm1+F1HFyTRErBUI=,iv:bVqvdB4CO4gf+6hK47EZqhVB2ZRgwqRBBSmWBBjr4UE=,tag:i/jbOubDXPIZG+FP8qWNxg==,type:str]
+    lastmodified: "2023-03-28T11:57:47Z"
+    mac: ENC[AES256_GCM,data:xQJtT4Qst7EE502xSANY7unvajbZexJ/sR1cvsVvkywGAbXz7LibCJAOztz225Vf9U+RGiNgpDuM98+hk2ZgQe0wAuJ05PbwPySVHZszhfse/dBhPSpdqJtMZb0GZ/P4/KEpU83QL0wF5AgmRUCyFtIEDL0N/tYu58rYXRQ34D8=,iv:DeRZXLtZcWskq93cm3tE8+11YirI/0Off4QBNwV79h0=,tag:7Bh3Ajd2zSC2jw//Ko9CZQ==,type:str]
     pgp:
-        - created_at: "2023-03-27T19:44:48Z"
+        - created_at: "2023-03-28T11:57:45Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA36KCQZTfcQcAQgAh0bw7Sf9C2l5A4SK75HBg83SLNPcu4dc70wGLuBfFGAg
-            Jg12Bn2uxDkqHAXk6ifRIcqp7wO/PWPXbygM2Ik5WFeZj/aCJPCfnv5qteVzJHr4
-            HyArPKMw6d5s+kBNA4GMZDURtCY0768QxrZWRqE7JX5282FfkVtJ5ORlzgOKYll4
-            JcujW1H/MKk9mh/u/sbulEq/p/KbMIcm+6GDhzvuQ0LRH6hOlzu3p89xtwuV2Zng
-            oXYgpcazJkdRPqwQq1l3Qr5lDUYIRH+4u6bEzkRLQXwTbjI4LZ9gD+xJp68i94e1
-            tCwe0pOwT1HX5GUdjFBVousM/TdkdkAAfn7QbhF6hNJcARSK1TBWfIcgyrEsu9kp
-            M4S/5MFHOQoE9fJYgeCJvgC7eyEbb7dEmRzzby6veY7hMwXrlNu6DzQRLxJuW66U
-            lorPmgThQR8tzdFbGmTqdx4QhAPOcFux7xxjVCE=
-            =U5Od
+            hQEMA36KCQZTfcQcAQf9EjoBwBh2b4Xj6aJLOpSTh83wuXSUm3QdExMi8V6oSV7h
+            LCgDDkCKCuJUFanYVVgJEFMgXqqqHZTemmORm8cwiYt112HPcUZ4oF5+tBwxDB0B
+            9B1oSY9p8Qy2Qiww0PGmMvfuJp7p7yghpiSH0MboPRh9hVpNbtq9GhCeLxNR8nUG
+            IiHXlVcbqoNzkhIHjwv6vnAGVpq77y+WjBCBlNbStOQoYdvg/XIm7+ezZ14B73SU
+            /yMeDQ9NOaKBJESfA7hn+FrWAoP19UB6DAYmd/OzpHZOXTW9C3q7m+Md7EQ9OvRT
+            HifBlbrt9WnpaHJxqx9zLNLxBUWVKGaqROWTTbNcjtJeAaTXvy97LcGZu/MkALs1
+            O9uiMFwcHGVAha5PjmhyS/sAt9nmfQnEZ9B7siKCUfJ79R6PNBTnm0LkKkQOIPZM
+            kRwQxGgRC9BjIrsJ6/yj8PHrRr/J+wVNcZVpBQn75Q==
+            =k5jC
             -----END PGP MESSAGE-----
           fp: 4A7B4BBC409CC1082AA3569F2B6D3A4FC69903B4
-        - created_at: "2023-03-27T19:44:48Z"
+        - created_at: "2023-03-28T11:57:45Z"
           enc: |
             -----BEGIN PGP MESSAGE-----
 
-            hQEMA/7PfFkhLfnLAQf/RVI1vhTwG/hWuvN+o6UgsPbXCF0GlgTVqzmeaSkcIqoA
-            i+gyXwsmxtteRiAn9FzSPD83HlonsFcDqpRSqfaocXeixaQqX385s563BNvulmhF
-            pdRGVuTl3UYVZgSk/K2pLC3wZT179vLz3fSgquiFeqOQVRAjG19sVB0fPlN9s8Ul
-            6x2S5l4vxpcL3mNIdQ9kR2y0q1LmfDm3TyFNWEcATC7VAUdAduj3FxBf/i/fArc6
-            vD9LWnx99XNUtEMNaPKM1C7ju9WFHv7Iy72BXd1VfOzvay8Da2w4SLc+mmIZqLlx
-            tTEzEkM2bRK1BeAiB57/fLrh8Ulk8+qIyR2ZWRdVQ9JcATP837EPAPL825eKVUBn
-            8MbVFXW+lTXkX/OSBKQqjqgdtcLcxNR1Tm5bvrXwtBblMi8wesdmWGq2lYxBiCkq
-            slF2JquQjEDYdmkGJQrnYf3kRi57Xk8iBwaggdc=
-            =0W36
+            hQEMA/7PfFkhLfnLAQf+NEN4nvyxF3nqzkCBpIhXHl8DlaWMMRDImRNhh1tsey46
+            gs9Lv/QESeYZ9d3jXu/Z5C/JY9I+A1TPEiWNpWNhQx9wc/9mGquTc44i2dlsoKFl
+            YZCZ9ZHtYSgaKJhstYsKu3Vbz9t13RrAy8djGk/vrcYvPRxkPWJUanuE26zKNH/l
+            LdKUAGYmCrC85WoR/D49Jyv2rWlmYNvTWhtS/r1tAvQU/QhoqEBKoItfYF97Zegq
+            A6kyT0URgpgyXQljbJIqyxQmFlDmfYpW4vbeIqIsKhhbCQh5KEIi4I3WwsBxavIK
+            /fvL9b2c0ZX/FxBAvn8W4OmRIM9pTSHPaaRjiJPGnNJeAYANJnsJ1xQGJ+yZXtxQ
+            jiwk8Thn8NezC7v5Up4Zgf43V6HRnRB8jcRMgR4OmSBS0h7m6ZkQ32/9V6+YU2O1
+            3FVomtpZq9YhPrv5pS15cEGeFbKhCO53RfgPraXtEg==
+            =cV69
             -----END PGP MESSAGE-----
           fp: B4F97D4CC0C01B52E7A511769129190A43B3AC94
     encrypted_regex: ^(password|clientSecret|value|privateKey|secret)$

--- a/jenkins-stack/casc_configs/jenkins-base.template.yaml
+++ b/jenkins-stack/casc_configs/jenkins-base.template.yaml
@@ -59,7 +59,7 @@ jobs:
         }
         projectFactories {
           workflowMultiBranchProjectFactory {
-            scriptPath('${JENKINSFILE_NAME}')
+            scriptPath('doppler-jenkins.groovy')
           }
         }
         buildStrategies {

--- a/jenkins-stack/prod.env
+++ b/jenkins-stack/prod.env
@@ -7,5 +7,4 @@ GITHUB_ACCESS=fromdoppler-access-ci
 # TODO: replace jenkins-new by jenkins
 CI_CONTEXT_LABEL=continuous-integration/jenkins-new
 # TODO: replace .doppler-ci-new by .doppler-ci
-JENKINSFILE_NAME=.doppler-ci-new
 BUILD_BRANCHES_REGEX='^(main|master|INT|integration|develop|TEST|PRODTEST|QA)$'

--- a/jenkins-stack/test.env
+++ b/jenkins-stack/test.env
@@ -3,5 +3,4 @@ ENVIRONMENT="test"
 DOPPLER_JENKINS_VERSION="INT"
 GITHUB_ACCESS=fromdoppler-access-test
 CI_CONTEXT_LABEL=continuous-integration/jenkins-test
-JENKINSFILE_NAME=.doppler-ci-test
 BUILD_BRANCHES_REGEX='^(TESTING-JENKINS)$'


### PR DESCRIPTION
Currently, our old Jenkins service (docker.fromdoppler.com) will keep using an empty suffix and the new Jenkins service (jenkins.fromdoppler.net) will use `_new` as the suffix of the generated packages.

During a transition period, the old Jenkins service (docker.fromdoppler.com) will use `_old` as a suffix and the new Jenkins service (jenkins.fromdoppler.net) will use an empty string as the suffix of the generated packages.

If all goes well, we will shut down the old Jenkins service and there will be no packages with suffixes.

**UPDATE:** I have also renamed Jenkinsfile as `doppler-jenkins.groovy` to have a new standard to identify the projects to build.