### PR TITLE
DE-971 - Jenkins test behavior

### DIFF
--- a/jenkins-stack/casc_configs/jenkins-base.template.yaml
+++ b/jenkins-stack/casc_configs/jenkins-base.template.yaml
@@ -59,7 +59,7 @@ jobs:
         }
         projectFactories {
           workflowMultiBranchProjectFactory {
-            scriptPath('doppler-jenkins.groovy')
+            scriptPath('${JENKINSFILE_NAME}')
           }
         }
         buildStrategies {

--- a/jenkins-stack/prod.env
+++ b/jenkins-stack/prod.env
@@ -4,7 +4,7 @@ DOPPLER_JENKINS_VERSION="main"
 # TODO: change to v1
 # DOPPLER_JENKINS_VERSION="v1"
 GITHUB_ACCESS=fromdoppler-access-ci
-# TODO: replace jenkins-new by jenkins
-CI_CONTEXT_LABEL=continuous-integration/jenkins-new
+# TODO: replace jenkins-ci by jenkins
+CI_CONTEXT_LABEL=continuous-integration/jenkins-ci
 BUILD_BRANCHES_REGEX='^(main|master|INT|integration|develop|TEST|PRODTEST|QA)$'
 JENKINSFILE_NAME=doppler-jenkins-ci.groovy

--- a/jenkins-stack/prod.env
+++ b/jenkins-stack/prod.env
@@ -6,6 +6,5 @@ DOPPLER_JENKINS_VERSION="main"
 GITHUB_ACCESS=fromdoppler-access-ci
 # TODO: replace jenkins-new by jenkins
 CI_CONTEXT_LABEL=continuous-integration/jenkins-new
-# TODO: replace .doppler-ci-new by .doppler-ci
 BUILD_BRANCHES_REGEX='^(main|master|INT|integration|develop|TEST|PRODTEST|QA)$'
 JENKINSFILE_NAME=doppler-jenkins-ci.groovy

--- a/jenkins-stack/prod.env
+++ b/jenkins-stack/prod.env
@@ -8,3 +8,4 @@ GITHUB_ACCESS=fromdoppler-access-ci
 CI_CONTEXT_LABEL=continuous-integration/jenkins-new
 # TODO: replace .doppler-ci-new by .doppler-ci
 BUILD_BRANCHES_REGEX='^(main|master|INT|integration|develop|TEST|PRODTEST|QA)$'
+JENKINSFILE_NAME=doppler-jenkins-ci.groovy

--- a/jenkins-stack/test.env
+++ b/jenkins-stack/test.env
@@ -4,3 +4,5 @@ DOPPLER_JENKINS_VERSION="INT"
 GITHUB_ACCESS=fromdoppler-access-test
 CI_CONTEXT_LABEL=continuous-integration/jenkins-test
 BUILD_BRANCHES_REGEX='^(TESTING-JENKINS)$'
+# If we want to run a JOB with testing instance, we should add this file
+JENKINSFILE_NAME=doppler-jenkins-test.groovy

--- a/jenkins-stack/test.env
+++ b/jenkins-stack/test.env
@@ -3,6 +3,6 @@ ENVIRONMENT="test"
 DOPPLER_JENKINS_VERSION="INT"
 GITHUB_ACCESS=fromdoppler-access-test
 CI_CONTEXT_LABEL=continuous-integration/jenkins-test
-BUILD_BRANCHES_REGEX='^(TESTING-JENKINS)$'
+BUILD_BRANCHES_REGEX='^(main|master|INT|integration|develop|TEST|PRODTEST|QA)$'
 # If we want to run a JOB with testing instance, we should add this file
 JENKINSFILE_NAME=doppler-jenkins-test.groovy


### PR DESCRIPTION
Using the Jenkins test instance was becoming too complex.

With this change, if we want to run a build with the Jenkins test instance, we should simply rename `doppler-jenkins-ci.groovy` by `doppler-jenkins-test.groovy` or also keeping both files to run the build with both instances.