### PR TITLE
feat: map pgp fingerprint to enable SOPS inside Jenkins

### DIFF
--- a/jenkins-stack/docker-compose.yml
+++ b/jenkins-stack/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - CASC_JENKINS_CONFIG=/jenkins-swarm/casc_configs
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - /root/.gnupg:/root/.gnupg
       - jenkins-data:/var/jenkins_home
     networks:
       - default


### PR DESCRIPTION
Allow Jenkins to access to the host's SOPS keys (GnuPG keys)