### PR TITLE
Support PRs from forks

### DIFF
--- a/cspell-project-words.txt
+++ b/cspell-project-words.txt
@@ -101,3 +101,4 @@ mozilla
 letsencrypt
 swarmpit
 couchdb
+jenkinsci

--- a/jenkins-stack/casc_configs/jenkins-base.template.yaml
+++ b/jenkins-stack/casc_configs/jenkins-base.template.yaml
@@ -1,6 +1,6 @@
 jenkins:
   systemMessage: |+
-    Doppler Jenkins ${ENVIRONMENT}
+    Doppler Jenkins ${JENKINS_PREFIX_SEGMENT}
   numExecutors: 5
   authorizationStrategy:
     # https://plugins.jenkins.io/github-oauth/
@@ -18,8 +18,8 @@ unclassified:
 jobs:
   - script: |
       organizationFolder('FromDoppler') {
-        description('FromDoppler GitHubOrganization ${ENVIRONMENT}')
-        displayName('FromDoppler ${ENVIRONMENT}')
+        description('FromDoppler GitHubOrganization ${JENKINS_PREFIX_SEGMENT}')
+        displayName('FromDoppler ${JENKINS_PREFIX_SEGMENT}')
         organizations {
           github {
             repoOwner('FromDoppler')
@@ -82,8 +82,8 @@ jobs:
         }
       }
       organizationFolder('MakingSense') {
-        description('MakingSense GitHubOrganization ${ENVIRONMENT}')
-        displayName('MakingSense ${ENVIRONMENT}')
+        description('MakingSense GitHubOrganization ${JENKINS_PREFIX_SEGMENT}')
+        displayName('MakingSense ${JENKINS_PREFIX_SEGMENT}')
         organizations {
           github {
             repoOwner('MakingSense')

--- a/jenkins-stack/casc_configs/jenkins-base.template.yaml
+++ b/jenkins-stack/casc_configs/jenkins-base.template.yaml
@@ -80,6 +80,15 @@ jobs:
         triggers {
           cron('@daily')
         }
+        configure { node ->
+          // node represents the node <org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator>
+          def traits = node / 'navigators' / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / 'traits'
+          // Also build PRs from forks
+          traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
+            strategyId('2')
+            trust(class: "org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission")
+          }
+        }
       }
       organizationFolder('MakingSense') {
         description('MakingSense GitHubOrganization ${JENKINS_PREFIX_SEGMENT}')
@@ -143,5 +152,14 @@ jobs:
         }
         triggers {
           cron('@daily')
+        }
+        configure { node ->
+          // node represents the node <org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator>
+          def traits = node / 'navigators' / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / 'traits'
+          // Also build PRs from forks
+          traits << 'org.jenkinsci.plugins.github__branch__source.ForkPullRequestDiscoveryTrait' {
+            strategyId('2')
+            trust(class: "org.jenkinsci.plugins.github_branch_source.ForkPullRequestDiscoveryTrait$TrustPermission")
+          }
         }
       }

--- a/jenkins-stack/docker-compose.yml
+++ b/jenkins-stack/docker-compose.yml
@@ -49,16 +49,16 @@ services:
       labels:
         - "traefik.enable=true"
         - "traefik.docker.network=traefik"
-        - "traefik.http.services.jenkins_service_${ENVIRONMENT:?}.loadbalancer.server.port=8080"
-        - "traefik.http.routers.jenkins_http_route_${ENVIRONMENT:?}.entrypoints=web_entry_point"
-        - "traefik.http.routers.jenkins_http_route_${ENVIRONMENT:?}.service=jenkins_service_${ENVIRONMENT:?}"
-        - "traefik.http.routers.jenkins_http_route_${ENVIRONMENT:?}.rule=Host(`${DOMAIN:?}`) && PathPrefix(`/${JENKINS_PREFIX_SEGMENT:?}/`)"
-        - "traefik.http.routers.jenkins_http_route_${ENVIRONMENT:?}.middlewares=http_to_https@file"
-        - "traefik.http.routers.jenkins_https_route_${ENVIRONMENT:?}.entrypoints=websecure_entry_point"
-        - "traefik.http.routers.jenkins_https_route_${ENVIRONMENT:?}.service=jenkins_service_${ENVIRONMENT:?}"
-        - "traefik.http.routers.jenkins_https_route_${ENVIRONMENT:?}.rule=Host(`${DOMAIN:?}`) && PathPrefix(`/${JENKINS_PREFIX_SEGMENT:?}/`)"
-        - "traefik.http.routers.jenkins_https_route_${ENVIRONMENT:?}.tls=true"
-        - "traefik.http.routers.jenkins_https_route_${ENVIRONMENT:?}.tls.certResolver=letsencryptresolver"
+        - "traefik.http.services.jenkins_service_${JENKINS_PREFIX_SEGMENT:?}.loadbalancer.server.port=8080"
+        - "traefik.http.routers.jenkins_http_route_${JENKINS_PREFIX_SEGMENT:?}.entrypoints=web_entry_point"
+        - "traefik.http.routers.jenkins_http_route_${JENKINS_PREFIX_SEGMENT:?}.service=jenkins_service_${JENKINS_PREFIX_SEGMENT:?}"
+        - "traefik.http.routers.jenkins_http_route_${JENKINS_PREFIX_SEGMENT:?}.rule=Host(`${DOMAIN:?}`) && PathPrefix(`/${JENKINS_PREFIX_SEGMENT:?}/`)"
+        - "traefik.http.routers.jenkins_http_route_${JENKINS_PREFIX_SEGMENT:?}.middlewares=http_to_https@file"
+        - "traefik.http.routers.jenkins_https_route_${JENKINS_PREFIX_SEGMENT:?}.entrypoints=websecure_entry_point"
+        - "traefik.http.routers.jenkins_https_route_${JENKINS_PREFIX_SEGMENT:?}.service=jenkins_service_${JENKINS_PREFIX_SEGMENT:?}"
+        - "traefik.http.routers.jenkins_https_route_${JENKINS_PREFIX_SEGMENT:?}.rule=Host(`${DOMAIN:?}`) && PathPrefix(`/${JENKINS_PREFIX_SEGMENT:?}/`)"
+        - "traefik.http.routers.jenkins_https_route_${JENKINS_PREFIX_SEGMENT:?}.tls=true"
+        - "traefik.http.routers.jenkins_https_route_${JENKINS_PREFIX_SEGMENT:?}.tls.certResolver=letsencryptresolver"
       replicas: ${REPLICAS:?}
       mode: replicated
       restart_policy:


### PR DESCRIPTION
Hi @leoslopez and team!

This PR adds support to PRs from forks.

It was not so easy because the plugin `github-branch-source` is not totally supported by `dsl-job`, but with some little research, I could fix it using the `configure` block.

Some useful resources:

- https://www.devexp.eu/2014/10/26/use-unsupported-jenkins-plugins-with-jenkins-dsl/
- https://github.com/jenkinsci/job-dsl-plugin/wiki/The-Configure-Block
- https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/demos/jobs/bitbucket.yaml