### PR TITLE
Shutdown test instance

### DIFF
--- a/jenkins-stack/test.env
+++ b/jenkins-stack/test.env
@@ -7,4 +7,4 @@ CI_CONTEXT_LABEL=continuous-integration/jenkins-test
 BUILD_BRANCHES_REGEX='^(main|master|INT|integration|develop|TEST|PRODTEST|QA)$'
 # If we want to run a JOB with testing instance, we should add this file
 JENKINSFILE_NAME=doppler-jenkins-test.groovy
-REPLICAS=1
+REPLICAS=0


### PR DESCRIPTION
Jenkins test instance could be useful in some scenarios, but right now we are not using it and it consumes some memory, so, it is better to shutdown it.

![image](https://user-images.githubusercontent.com/1157864/233088120-0c78f290-d7d3-49af-9fd8-bdce5981545e.png)
