### PR TITLE
Improve docker prune

### DIFF
--- a/cronjob-stack/docker-compose.yml
+++ b/cronjob-stack/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     logging: *default-logging
   prune-docker:
     image: docker
-    command: ["docker", "system", "prune", "-f", "--filter", "until=2h"]
+    command: ["docker", "system", "prune", "-a", "-f", "--filter", "until=2h"]
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     deploy:

--- a/cronjob-stack/docker-compose.yml
+++ b/cronjob-stack/docker-compose.yml
@@ -22,7 +22,10 @@ services:
     logging: *default-logging
   prune-docker:
     image: docker
-    command: ["docker", "system", "prune", "-a", "-f", "--filter", "until=2h"]
+    command:
+      - sh
+      - -c
+      - docker system prune --all --force --filter until=2h
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     deploy:

--- a/cronjob-stack/docker-compose.yml
+++ b/cronjob-stack/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - >
         date +'%Y-%m-%d %H:%I:%S' &&
         docker system prune --all --force --filter until=2h &&
+        df -h / &&
         echo ""
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/cronjob-stack/docker-compose.yml
+++ b/cronjob-stack/docker-compose.yml
@@ -20,16 +20,16 @@ services:
         constraints:
           - node.role == manager
     logging: *default-logging
-  prune-docker-until-1h-each-15m:
+  prune-docker:
     image: docker
-    command: ["docker", "system", "prune", "-f", "--filter", "until=1h"]
+    command: ["docker", "system", "prune", "-f", "--filter", "until=2h"]
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     deploy:
       mode: global
       labels:
         - "swarm.cronjob.enable=true"
-        - "swarm.cronjob.schedule=*/15 * * * *"
+        - "swarm.cronjob.schedule=*/10 * * * *"
         - "swarm.cronjob.skip-running=true"
       restart_policy:
         condition: none

--- a/cronjob-stack/docker-compose.yml
+++ b/cronjob-stack/docker-compose.yml
@@ -25,7 +25,10 @@ services:
     command:
       - sh
       - -c
-      - docker system prune --all --force --filter until=2h
+      - >
+        date +'%Y-%m-%d %H:%I:%S' &&
+        docker system prune --all --force --filter until=2h &&
+        echo ""
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     deploy:


### PR DESCRIPTION
I missed the `--all` option and it was not removing the unused images.

Now, I am running it each ten minutes and with the 2h until option.

It is also showing a more descriptive output:

![image](https://user-images.githubusercontent.com/1157864/233476466-3c9a68f4-453a-46ce-8cdf-209e787d4c10.png)
