### PR TITLE
fix: clean packages older than a hour in place of two

### DIFF
--- a/cronjob-stack/docker-compose.yml
+++ b/cronjob-stack/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - -c
       - >
         date +'%Y-%m-%d %H:%I:%S' &&
-        docker system prune --all --force --filter until=2h &&
+        docker system prune --all --force --filter until=1h &&
         df -h / &&
         echo ""
     volumes:


### PR DESCRIPTION
We are receiving more of these errors: 

![image](https://user-images.githubusercontent.com/1157864/236215477-27194fa1-0075-45ce-a7df-6fda61f0b13a.png)

Hope this help.