### PR TITLE
docs: add instructions to clean up docker wasted space

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,3 +29,4 @@ doppler-jenkins-ci.groovy
 id_rsa.pub
 host-setup/ssh/*
 **/*.GENERATED.*
+**/aws/config

--- a/README.md
+++ b/README.md
@@ -142,3 +142,31 @@ Swarm will be responsible to run our docker containers and keep them up.
 
    docker node update --label-add safevolumes=true {node id}
    ```
+
+## Clean up wasted space and minimal state backup
+
+`docker system prune --all` is not enough to avoid a leak of the space, `prune` does not clean all the unused docker objects.
+
+Ideally, we could clean up all the disk structure and start from the beginning with this repository, but it will lose the build history and Jenkins' state. It is stored in the named volumes, currently, we have these:
+
+- `/var/lib/docker/volumes/jenkins-prod_jenkins-data`
+- `/var/lib/docker/volumes/jenkins-test_jenkins-data`
+- `/var/lib/docker/volumes/swarmpit_db-data`
+- `/var/lib/docker/volumes/swarmpit_influx-data`
+- `/var/lib/docker/volumes/traefik_traefik-acme`
+
+So, it is possible to back up those folders, start the server again from a pristine status, restore the folders, and start docker.
+
+To quickly clean up Docker objects, this process is not so complete, but it is easier and it works:
+
+```shell
+systemctl stop docker.socket
+rm -rf /var/lib/docker/overlay2/*
+rm -rf /var/lib/docker/containers/*
+rm -rf /var/lib/docker/image/*
+systemctl start docker.socket
+docker system prune --all
+sh /swarm-cd/deploy-shared-stacks.sh
+sh /swarm-cd/deploy-test-stacks.sh
+sh /swarm-cd/deploy-prod-stacks.sh
+```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ apt-get install \
    ca-certificates \
    curl \
    gnupg \
-   git
+   git \
+   rsync
 
 # See https://docs.docker.com/engine/install/debian/
 # shellcheck disable=SC2174
@@ -160,10 +161,12 @@ So, it is possible to back up those folders, start the server again from a prist
 To quickly clean up Docker objects, this process is not so complete, but it is easier and it works:
 
 ```shell
+# Having an empty folder is a precondition for the optimized cleanup
+# rm -rf /empty/ && mkdir -p /empty/
 systemctl stop docker.socket
-rm -rf /var/lib/docker/overlay2/*
-rm -rf /var/lib/docker/containers/*
-rm -rf /var/lib/docker/image/*
+rsync -a --delete /empty/ /var/lib/docker/overlay2/
+rsync -a --delete /empty/ /var/lib/docker/containers/
+rsync -a --delete /empty/ /var/lib/docker/image/
 systemctl start docker.socket
 docker system prune --all
 sh /swarm-cd/deploy-shared-stacks.sh

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ It will allow us to use decrypt the configuration files.
    rm /swarm-cd/sops/Production.priv.key
    ```
 
-# Create Swarm
+### Create Swarm
 
 Swarm will be responsible to run our docker containers and keep them up.
 

--- a/cronjob-stack/docker-compose.yml
+++ b/cronjob-stack/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       mode: global
       labels:
         - "swarm.cronjob.enable=true"
-        - "swarm.cronjob.schedule=5 */2 * * *"
+        - "swarm.cronjob.schedule=5 0 * * *"
         - "swarm.cronjob.skip-running=true"
       restart_policy:
         condition: none


### PR DESCRIPTION
I tested these steps in a clone of our server.

It is ready to review. If there is no criticism, I will apply them to our _official_ Jenkins and then merge it.

> ## Clean up wasted space and minimal state backup
> 
> `docker system prune --all` is not enough to avoid a leak of the space, `prune` does not clean all the unused docker objects.
> 
> Ideally, we could clean up all the disk structure and start from the beginning with this repository, but it will lose the build > history and Jenkins' state. It is stored in the named volumes, currently, we have these:
> 
> - `/var/lib/docker/volumes/jenkins-prod_jenkins-data`
> - `/var/lib/docker/volumes/jenkins-test_jenkins-data`
> - `/var/lib/docker/volumes/swarmpit_db-data`
> - `/var/lib/docker/volumes/swarmpit_influx-data`
> - `/var/lib/docker/volumes/traefik_traefik-acme`
> 
> So, it is possible to back up those folders, start the server again from a pristine status, restore the folders, and start > docker.
> 
> To quickly clean up Docker objects, this process is not so complete, but it is easier and it works:
> 
> ```shell
> # Having an empty folder is a precondition for the optimized cleanup
> # rm -rf /empty/ && mkdir -p /empty/
> systemctl stop docker.socket
> rsync -a --delete /empty/ /var/lib/docker/overlay2/
> rsync -a --delete /empty/ /var/lib/docker/containers/
> rsync -a --delete /empty/ /var/lib/docker/image/
> systemctl start docker.socket
> docker system prune --all
> sh /swarm-cd/deploy-shared-stacks.sh
> sh /swarm-cd/deploy-test-stacks.sh
> sh /swarm-cd/deploy-prod-stacks.sh
> ```

Related to [DOP-1440](https://makingsense.atlassian.net/browse/DOP-1440)

[DOP-1440]: https://makingsense.atlassian.net/browse/DOP-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ